### PR TITLE
Updated API paths

### DIFF
--- a/exporter/technitium-exporter.py
+++ b/exporter/technitium-exporter.py
@@ -11,8 +11,8 @@ from prometheus_client import Gauge, start_http_server
 class Technitium_exporter:
     def __init__(self, url, username, password, token):
         self.api_url = f"{url}/api"
-        self.login_url = f"{self.api_url}/login?user={username}&pass={password}"
-        self.status_url = f"{self.api_url}/getStats?type=lastDay"
+        self.login_url = f"{self.api_url}/user/login?user={username}&pass={password}"
+        self.status_url = f"{self.api_url}/dashboard/stats/get?type=lastDay"
         self.stat_prefix = "technitium"
         self.stats = None
         self.token = token


### PR DESCRIPTION
The API paths for login and stats have been changed a while ago. This PR updates those paths in the exporter.

[Login](https://github.com/TechnitiumSoftware/DnsServer/blob/844410831092f54f604529fb1437e989566a01e2/APIDOCS.md?plain=1#L58)
[Get Stats](https://github.com/TechnitiumSoftware/DnsServer/blob/844410831092f54f604529fb1437e989566a01e2/APIDOCS.md?plain=1#L469)