### PR TITLE
Github Actions to build and push docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "docker_build"
 
 jobs:
   docker:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,31 @@
+name: docker
+
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-      - "docker_build"
 
 jobs:
   docker:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   technitium-exporter:
-    image: arivera3483/technitium-exporter
+    image: ghcr.io/kgleeson/technitium_exporter:latest
     container_name: technitium_exporter
     expose:
       - 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   technitium-exporter:
-    image: technitium-exporter
+    image: ghcr.io/kgleeson/technitium_exporter:latest
     container_name: technitium_exporter
     expose:
       - 8080


### PR DESCRIPTION
As suggested by @UntouchedWagons in issue #3 I've added a simple Github Actions workflow to the repo that will build a docker image and push it to the Github registry whenever something is pushed/merged to the master branch. The image is built for `amd64` and `arm64` architectures since those are probably the most popular ones for self hosting stuff.
I've also updated the docker compose files to use the image that this workflow will build.

You can see an example of a succesful Actions run in my fork: https://github.com/traxo-xx/technitium_exporter/actions/runs/7408660885
This is the build image in my fork: https://github.com/traxo-xx/technitium_exporter/pkgs/container/technitium_exporter